### PR TITLE
Add roles to user instead of using role mappings

### DIFF
--- a/vendor/github.com/WhizUs/go-opendistro/security/user.go
+++ b/vendor/github.com/WhizUs/go-opendistro/security/user.go
@@ -24,6 +24,7 @@ type UserServiceInterface interface {
 type UserCreate struct {
 	Password     string            `json:"password,omitempty"`
 	BackendRoles []string          `json:"backend_roles,omitempty"`
+    Roles        []string          `json:"opendistro_security_roles"`
 	Attributes   map[string]string `json:"attributes,omitempty"`
 }
 


### PR DESCRIPTION
This also fixes the issue that two leases with the same externally defined roles overwrite each others role mappings.